### PR TITLE
Fix metadata preservation on update

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -658,11 +658,19 @@ async function handleUpdateLink(request, env, corsHeaders) {
     // Update the URL mapping
     await env.SHORT_URL_STORE.put(path, newUrl);
     
-    // Update metadata
+    // Retrieve existing metadata to preserve creation date
+    let existingMetadata;
+    try {
+        const stored = await env.SHORT_URL_STORE.get(`meta:${path}`);
+        existingMetadata = stored ? JSON.parse(stored) : null;
+    } catch (_) {
+        existingMetadata = null;
+    }
+
     const metadata = {
         path,
         url: newUrl,
-        created: new Date().toISOString(),
+        created: existingMetadata?.created || new Date().toISOString(),
         updated: new Date().toISOString()
     };
     await env.SHORT_URL_STORE.put(`meta:${path}`, JSON.stringify(metadata));


### PR DESCRIPTION
## Summary
- keep the original `created` timestamp when updating a short URL

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d4504bc2883209e16026c32a0826e